### PR TITLE
feat: Check for readline library before Lua installation

### DIFF
--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -6,6 +6,10 @@ local Utils = require("utils")
 --- @field ctx.version string User-input version
 --- @return table Version information
 function PLUGIN:PreInstall(ctx)
+    if not Utils.check_readline_installed() then
+        print("Error: readline library not found. Please install readline development packages (e.g., libreadline-dev or readline-devel) and try again.")
+        error("readline library not found")
+    end
     local lua_version = ctx.version
     local download_url
 

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -37,5 +37,24 @@ function lua_utils.is_dir(path)
     return status == 0
 end
 
+function lua_utils.check_readline_installed()
+    -- Check if the OS is Linux
+    if package.config:sub(1,1) == '/' then
+        -- On Linux, check for readline library
+        -- Check for header files
+        if os.execute("test -f /usr/include/readline/readline.h") == 0 or \
+           os.execute("test -f /usr/local/include/readline/readline.h") == 0 or \
+           os.execute("test -f /usr/include/readline.h") == 0 or \
+           -- Check with ldconfig
+           os.execute("ldconfig -p | grep -q libreadline") == 0 then
+            return true
+        else
+            return false
+        end
+    else
+        -- Not Linux, assume readline is available or not needed
+        return true
+    end
+end
 
 return lua_utils


### PR DESCRIPTION
This commit introduces a check for the readline library before proceeding with Lua installation.

The changes include:
- A new utility function `check_readline_installed` in `lib/utils.lua`. This function verifies if the readline development headers or library are present on Linux systems. For non-Linux systems, it defaults to true.
- The `hooks/pre_install.lua` script now calls this utility function. If readline is not detected on a Linux system, an error message is displayed, and the installation is halted.

This addresses issue #2, ensuring you are notified about missing readline dependencies, which are crucial for Lua's interactive mode and other features.