### PR TITLE
Add optional Windows LuaBinaries installs

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -269,3 +269,53 @@ jobs:
           $HOME/.local/bin/mise exec -- luarocks --version
           $HOME/.local/bin/mise exec -- luarocks install luacheck
           $HOME/.local/bin/mise exec -- luarocks list | grep luacheck
+
+  windows_luabinaries_tests:
+    strategy:
+      matrix:
+        lua_version: [5.5.0, 5.4.8, 5.3.6]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.24.2'
+
+      - name: build & install vfox
+        shell: pwsh
+        run: |
+          git clone https://github.com/version-fox/vfox.git
+          cd vfox
+          go build -o vfox.exe
+          echo "$pwd" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          ./vfox.exe -version
+
+      - name: add vfox-lua plugin
+        shell: pwsh
+        run: |
+          vfox add --source https://github.com/${{ github.repository_owner }}/vfox-lua/archive/$env:GITHUB_REF.zip lua
+
+      - name: install Lua from LuaBinaries by vfox-lua plugin
+        shell: pwsh
+        env:
+          LUA_VERSION: "${{ matrix.lua_version }}"
+          VFOX_LUA_WINDOWS_LUABINARIES: "1"
+        run: |
+          vfox install "lua@$env:LUA_VERSION"
+          Invoke-Expression "$(vfox activate pwsh)"
+          vfox use -g "lua@$env:LUA_VERSION"
+          Invoke-Expression "$(vfox activate pwsh)"
+          echo "===============PATH==============="
+          echo $env:PATH
+          echo "===============PATH==============="
+          $luaVersion = lua.exe -v
+          $luacVersion = luac.exe -v
+          if ($luaVersion -notmatch "Lua $env:LUA_VERSION") {
+              Write-Output "lua@$env:LUA_VERSION installed from LuaBinaries failed!"
+              exit 1
+          }
+          if ($luacVersion -notmatch "Lua $env:LUA_VERSION") {
+              Write-Output "luac@$env:LUA_VERSION installed from LuaBinaries failed!"
+              exit 1
+          }

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: add vfox-lua plugin
         if: runner.os == 'Windows'
         run: |
-          vfox add --source https://github.com/${{ github.repository_owner }}/vfox-lua/archive/$env:GITHUB_REF.zip lua
+          vfox add --source "https://github.com/${{ github.repository_owner }}/vfox-lua/archive/${env:GITHUB_REF}.zip" lua
 
       - name: add vfox-lua plugin
         if: runner.os != 'Windows'
@@ -294,7 +294,7 @@ jobs:
       - name: add vfox-lua plugin
         shell: pwsh
         run: |
-          vfox add --source https://github.com/${{ github.repository_owner }}/vfox-lua/archive/$env:GITHUB_REF.zip lua
+          vfox add --source "https://github.com/${{ github.repository_owner }}/vfox-lua/archive/${env:GITHUB_REF}.zip" lua
 
       - name: install Lua from LuaBinaries by vfox-lua plugin
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ luarocks install luacheck
 
 3. On Windows, use `PowerShell` to install Lua.
 
-4. `VFOX_LUA_WINDOWS_LUABINARIES=1` is a Windows-only opt-in. If the requested version is not published by LuaBinaries, the install will fail and you should use the default source-build flow instead.
+4. `VFOX_LUA_WINDOWS_LUABINARIES=1` is a Windows-only opt-in. If the requested version is not published by LuaBinaries, the install will fail and you should use the default source-build flow instead. The archive is downloaded from SourceForge's mirror autoselect over HTTPS; checksum verification is currently skipped because the redirected mirrors don't yield a stable hash. Prefer the default source-build flow if you require an integrity check.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Lua [vfox](https://github.com/version-fox) plugin. Use the vfox to manage multip
   - GCC compiler
   - Make
 
+Optional on Windows:
+- Set `VFOX_LUA_WINDOWS_LUABINARIES=1` to install a prebuilt LuaBinaries package instead of compiling from source
+- Supported LuaBinaries versions: `5.5.0`, `5.4.8`, `5.3.6`, `5.2.4`
+
 ## Usage
 
 ### Install with vfox
@@ -36,6 +40,15 @@ vfox install lua@5.4.7
 
 # activate
 vfox use -g lua@5.4.7
+```
+
+On Windows, you can opt into prebuilt LuaBinaries packages instead of the default MSYS2 source build:
+
+```powershell
+$env:VFOX_LUA_WINDOWS_LUABINARIES=1
+vfox install lua@5.5.0
+vfox use -g lua@5.5.0
+lua -v
 ```
 
 ### Install with mise
@@ -91,6 +104,8 @@ luarocks install luacheck
    - macOS: `brew install readline`
 
 3. On Windows, use `PowerShell` to install Lua.
+
+4. `VFOX_LUA_WINDOWS_LUABINARIES=1` is a Windows-only opt-in. If the requested version is not published by LuaBinaries, the install will fail and you should use the default source-build flow instead.
 
 ## Known Issues
 

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -1,5 +1,3 @@
-local Utils = require("utils")
-
 --- Each SDK may have different environment variable configurations.
 --- This allows plugins to define custom environment variables (including PATH settings)
 --- @param ctx table Context information
@@ -18,11 +16,19 @@ function PLUGIN:EnvKeys(ctx)
         },
     }
 
-    if RUNTIME.osType == "windows" and Utils.use_windows_luabinaries() then
-        table.insert(envs, 1, {
-            key = "PATH",
-            value = installDir,
-        })
+    -- LuaBinaries installs place lua.exe in the install root next to the DLL; MSYS2 source
+    -- builds only populate bin/. Detect the LuaBinaries layout by probing the file so PATH
+    -- stays correct on `vfox use` even when VFOX_LUA_WINDOWS_LUABINARIES (an install-time
+    -- opt-in) is no longer exported in the activation shell.
+    if RUNTIME.osType == "windows" then
+        local rootLua = io.open(installDir .. "/lua.exe", "r")
+        if rootLua ~= nil then
+            rootLua:close()
+            table.insert(envs, 1, {
+                key = "PATH",
+                value = installDir,
+            })
+        end
     end
 
     local luarocksBin = installDir .. "/luarocks/bin"

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -16,6 +16,16 @@ function PLUGIN:EnvKeys(ctx)
         },
     }
 
+    local rootLua = installDir .. "/lua.exe"
+    local rootLuaFile = io.open(rootLua, "r")
+    if rootLuaFile ~= nil then
+        rootLuaFile:close()
+        table.insert(envs, 1, {
+            key = "PATH",
+            value = installDir,
+        })
+    end
+
     local luarocksBin = installDir .. "/luarocks/bin"
     local f = io.open(luarocksBin, "r")
     if f ~= nil then

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -1,3 +1,5 @@
+local Utils = require("utils")
+
 --- Each SDK may have different environment variable configurations.
 --- This allows plugins to define custom environment variables (including PATH settings)
 --- @param ctx table Context information
@@ -16,10 +18,7 @@ function PLUGIN:EnvKeys(ctx)
         },
     }
 
-    local rootLua = installDir .. "/lua.exe"
-    local rootLuaFile = io.open(rootLua, "r")
-    if rootLuaFile ~= nil then
-        rootLuaFile:close()
+    if RUNTIME.osType == "windows" and Utils.use_windows_luabinaries() then
         table.insert(envs, 1, {
             key = "PATH",
             value = installDir,

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -5,7 +5,7 @@
 function PLUGIN:EnvKeys(ctx)
     local sdkInfo = ctx.sdkInfo["lua"]
     local version = sdkInfo.version
-    local installDir = sdkInfo.path
+    local installDir = ctx.path
 
     local shortVersion = string.match(version, "^(%d+%.%d+)")
 

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -25,8 +25,8 @@ Make sure make.exe and gcc.exe are in the System $env:PATH in PowerShell.
 end
 
 local function InstallWindowsLuaBinaries(path, lua_version)
-    local package = Utils.get_windows_luabinaries_package(lua_version)
-    if package == nil then
+    local pkg_meta = Utils.get_windows_luabinaries_package(lua_version)
+    if pkg_meta == nil then
         error("LuaBinaries package metadata missing for version " .. lua_version)
     end
 
@@ -48,11 +48,11 @@ if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $inst
 if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force }
 ]=],
         path,
-        package.executable_prefix,
-        string.sub(package.executable_prefix, 4),
-        package.wlua_prefix,
-        package.dll_name,
-        package.dll_name
+        pkg_meta.executable_prefix,
+        string.sub(pkg_meta.executable_prefix, 4),
+        pkg_meta.wlua_prefix,
+        pkg_meta.dll_name,
+        pkg_meta.dll_name
     )
 
     local script_file = io.open(script_path, "w")
@@ -62,13 +62,15 @@ if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir
     script_file:write(script_content)
     script_file:close()
 
+    local powershell_script_path = string.gsub(script_path, "\\", "/")
+    powershell_script_path = string.gsub(powershell_script_path, "'", "''")
     local cmd = string.format(
-        "powershell -NoProfile -ExecutionPolicy Bypass -File %s",
-        script_path
+        "powershell -NoProfile -ExecutionPolicy Bypass -Command \"& '%s'\"",
+        powershell_script_path
     )
     local status = os.execute(cmd)
     os.remove(script_path)
-    if status ~= 0 then
+    if not Utils.is_success_status(status) then
         error("failed to prepare LuaBinaries files for Windows")
     end
 end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -31,21 +31,7 @@ local function InstallWindowsLuaBinaries(path, lua_version)
     end
 
     local cmd = string.format([=[
-powershell -Command "
-$ErrorActionPreference = 'Stop';
-$installDir = '%s';
-$binDir = Join-Path $installDir 'bin';
-New-Item -ItemType Directory -Force -Path $binDir | Out-Null;
-$luaExe = Join-Path $installDir '%s.exe';
-$luacExe = Join-Path $installDir 'luac%s.exe';
-$wluaExe = Join-Path $installDir '%s.exe';
-$luaDll = Join-Path $installDir '%s';
-if (-not (Test-Path $luaExe)) { throw 'LuaBinaries executable package layout is unexpected.' }
-Copy-Item -Path $luaExe -Destination (Join-Path $binDir 'lua.exe') -Force;
-if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force; }
-if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force; }
-if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force; }
-"
+powershell -NoProfile -Command "& { $ErrorActionPreference = 'Stop'; $installDir = '%s'; $binDir = Join-Path $installDir 'bin'; New-Item -ItemType Directory -Force -Path $binDir | Out-Null; $luaExe = Join-Path $installDir '%s.exe'; $luacExe = Join-Path $installDir 'luac%s.exe'; $wluaExe = Join-Path $installDir '%s.exe'; $luaDll = Join-Path $installDir '%s'; if (-not (Test-Path $luaExe)) { throw 'LuaBinaries executable package layout is unexpected.' }; Copy-Item -Path $luaExe -Destination (Join-Path $binDir 'lua.exe') -Force; if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force }; if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force }; if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force } }"
 ]=],
         path,
         package.executable_prefix,

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -63,7 +63,7 @@ if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir
     script_file:close()
 
     local cmd = string.format(
-        "powershell -NoProfile -ExecutionPolicy Bypass -File \"%s\"",
+        "powershell -NoProfile -ExecutionPolicy Bypass -File %s",
         script_path
     )
     local status = os.execute(cmd)

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -1,3 +1,5 @@
+local Utils = require("utils")
+
 --- Extension point, called after PreInstall, can perform additional operations,
 --- such as file operations for the SDK installation directory or compile source code
 function CheckBuildTools(osType)
@@ -22,6 +24,43 @@ Make sure make.exe and gcc.exe are in the System $env:PATH in PowerShell.
     end
 end
 
+local function InstallWindowsLuaBinaries(path, lua_version)
+    local package = Utils.get_windows_luabinaries_package(lua_version)
+    if package == nil then
+        error("LuaBinaries package metadata missing for version " .. lua_version)
+    end
+
+    local cmd = string.format([=[
+powershell -Command "
+$ErrorActionPreference = 'Stop';
+$installDir = '%s';
+$binDir = Join-Path $installDir 'bin';
+New-Item -ItemType Directory -Force -Path $binDir | Out-Null;
+$luaExe = Join-Path $installDir '%s.exe';
+$luacExe = Join-Path $installDir 'luac%s.exe';
+$wluaExe = Join-Path $installDir '%s.exe';
+$luaDll = Join-Path $installDir '%s';
+if (-not (Test-Path $luaExe)) { throw 'LuaBinaries executable package layout is unexpected.' }
+Copy-Item -Path $luaExe -Destination (Join-Path $binDir 'lua.exe') -Force;
+if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force; }
+if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force; }
+if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force; }
+"
+]=],
+        path,
+        package.executable_prefix,
+        string.sub(package.executable_prefix, 4),
+        package.wlua_prefix,
+        package.dll_name,
+        package.dll_name
+    )
+
+    local status = os.execute(cmd)
+    if status ~= 0 then
+        error("failed to prepare LuaBinaries files for Windows")
+    end
+end
+
 
 function PLUGIN:PostInstall(ctx)
     --- ctx.rootPath SDK installation directory
@@ -31,6 +70,11 @@ function PLUGIN:PostInstall(ctx)
     local normalizedPath = string.gsub(path, "\\", "/")
     local lua_version = sdkInfo.version
     print(string.format("os type: %s, lua installed path: %s", RUNTIME.osType, path))
+
+    if RUNTIME.osType == "windows" and Utils.use_windows_luabinaries() then
+        InstallWindowsLuaBinaries(path, lua_version)
+        return
+    end
 
     CheckBuildTools(RUNTIME.osType)
     -- TODO: support install luajit

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -24,54 +24,73 @@ Make sure make.exe and gcc.exe are in the System $env:PATH in PowerShell.
     end
 end
 
+local function copy_file(src, dst)
+    local input = io.open(src, "rb")
+    if input == nil then
+        return false
+    end
+    local content = input:read("*a")
+    input:close()
+
+    local output = io.open(dst, "wb")
+    if output == nil then
+        return false
+    end
+    output:write(content)
+    output:close()
+    return true
+end
+
+local function file_exists(path)
+    local f = io.open(path, "rb")
+    if f == nil then
+        return false
+    end
+    f:close()
+    return true
+end
+
 local function InstallWindowsLuaBinaries(path, lua_version)
     local pkg_meta = Utils.get_windows_luabinaries_package(lua_version)
     if pkg_meta == nil then
         error("LuaBinaries package metadata missing for version " .. lua_version)
     end
 
-    local script_path = path .. "\\install_luabinaries.ps1"
-    local script_content = string.format([=[
-$ErrorActionPreference = 'Stop'
-$installDir = '%s'
-$binDir = Join-Path $installDir 'bin'
-New-Item -ItemType Directory -Force -Path $binDir | Out-Null
-$luaExe = Join-Path $installDir '%s.exe'
-$luacExe = Join-Path $installDir 'luac%s.exe'
-$wluaExe = Join-Path $installDir '%s.exe'
-$luaDll = Join-Path $installDir '%s'
-if (-not (Test-Path $luaExe)) { throw 'LuaBinaries executable package layout is unexpected.' }
-Copy-Item -Path $luaExe -Destination (Join-Path $installDir 'lua.exe') -Force
-Copy-Item -Path $luaExe -Destination (Join-Path $binDir 'lua.exe') -Force
-if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $installDir 'luac.exe') -Force; Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force }
-if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $installDir 'wlua.exe') -Force; Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force }
-if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force }
-]=],
-        path,
-        pkg_meta.executable_prefix,
-        string.sub(pkg_meta.executable_prefix, 4),
-        pkg_meta.wlua_prefix,
-        pkg_meta.dll_name,
-        pkg_meta.dll_name
-    )
+    local bin_dir = path .. "\\bin"
+    os.execute(string.format('if not exist "%s" mkdir "%s"', bin_dir, bin_dir))
 
-    local script_file = io.open(script_path, "w")
-    if script_file == nil then
-        error("failed to create temporary LuaBinaries install script")
+    local lua_exe = path .. "\\" .. pkg_meta.executable_prefix .. ".exe"
+    if not file_exists(lua_exe) then
+        error("LuaBinaries executable not found at " .. lua_exe)
     end
-    script_file:write(script_content)
-    script_file:close()
 
-    local powershell_script_path = string.gsub(script_path, "\\", "/")
-    powershell_script_path = string.gsub(powershell_script_path, "'", "''")
-    local cmd = string.format(
-        "powershell -NoProfile -ExecutionPolicy Bypass -Command \"& '%s'\"",
-        powershell_script_path
-    )
-    local status = os.execute(cmd)
-    os.remove(script_path)
-    if not Utils.is_success_status(status) then
-        error("failed to prepare LuaBinaries files for Windows")
+    local copies = {
+        { src = lua_exe, dst = path .. "\\lua.exe" },
+        { src = lua_exe, dst = bin_dir .. "\\lua.exe" },
+    }
+
+    local luac_prefix = "luac" .. string.sub(pkg_meta.executable_prefix, 4)
+    local luac_exe = path .. "\\" .. luac_prefix .. ".exe"
+    if file_exists(luac_exe) then
+        table.insert(copies, { src = luac_exe, dst = path .. "\\luac.exe" })
+        table.insert(copies, { src = luac_exe, dst = bin_dir .. "\\luac.exe" })
+    end
+
+    local wlua_exe = path .. "\\" .. pkg_meta.wlua_prefix .. ".exe"
+    if file_exists(wlua_exe) then
+        table.insert(copies, { src = wlua_exe, dst = path .. "\\wlua.exe" })
+        table.insert(copies, { src = wlua_exe, dst = bin_dir .. "\\wlua.exe" })
+    end
+
+    local lua_dll = path .. "\\" .. pkg_meta.dll_name
+    if file_exists(lua_dll) then
+        table.insert(copies, { src = lua_dll, dst = bin_dir .. "\\" .. pkg_meta.dll_name })
+    end
+
+    for _, item in ipairs(copies) do
+        if not copy_file(item.src, item.dst) then
+            error("failed to copy " .. item.src .. " to " .. item.dst)
+        end
     end
 end
 

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -30,8 +30,21 @@ local function InstallWindowsLuaBinaries(path, lua_version)
         error("LuaBinaries package metadata missing for version " .. lua_version)
     end
 
-    local cmd = string.format([=[
-powershell -NoProfile -Command "& { $ErrorActionPreference = 'Stop'; $installDir = '%s'; $binDir = Join-Path $installDir 'bin'; New-Item -ItemType Directory -Force -Path $binDir | Out-Null; $luaExe = Join-Path $installDir '%s.exe'; $luacExe = Join-Path $installDir 'luac%s.exe'; $wluaExe = Join-Path $installDir '%s.exe'; $luaDll = Join-Path $installDir '%s'; if (-not (Test-Path $luaExe)) { throw 'LuaBinaries executable package layout is unexpected.' }; Copy-Item -Path $luaExe -Destination (Join-Path $binDir 'lua.exe') -Force; if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force }; if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force }; if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force } }"
+    local script_path = path .. "\\install_luabinaries.ps1"
+    local script_content = string.format([=[
+$ErrorActionPreference = 'Stop'
+$installDir = '%s'
+$binDir = Join-Path $installDir 'bin'
+New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+$luaExe = Join-Path $installDir '%s.exe'
+$luacExe = Join-Path $installDir 'luac%s.exe'
+$wluaExe = Join-Path $installDir '%s.exe'
+$luaDll = Join-Path $installDir '%s'
+if (-not (Test-Path $luaExe)) { throw 'LuaBinaries executable package layout is unexpected.' }
+Copy-Item -Path $luaExe -Destination (Join-Path $binDir 'lua.exe') -Force
+if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force }
+if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force }
+if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force }
 ]=],
         path,
         package.executable_prefix,
@@ -41,7 +54,19 @@ powershell -NoProfile -Command "& { $ErrorActionPreference = 'Stop'; $installDir
         package.dll_name
     )
 
+    local script_file = io.open(script_path, "w")
+    if script_file == nil then
+        error("failed to create temporary LuaBinaries install script")
+    end
+    script_file:write(script_content)
+    script_file:close()
+
+    local cmd = string.format(
+        "powershell -NoProfile -ExecutionPolicy Bypass -File \"%s\"",
+        script_path
+    )
     local status = os.execute(cmd)
+    os.remove(script_path)
     if status ~= 0 then
         error("failed to prepare LuaBinaries files for Windows")
     end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -56,9 +56,10 @@ local function InstallWindowsLuaBinaries(path, lua_version)
         error("LuaBinaries package metadata missing for version " .. lua_version)
     end
 
-    local bin_dir = path .. "\\bin"
-    os.execute(string.format('if not exist "%s" mkdir "%s"', bin_dir, bin_dir))
-
+    -- LuaBinaries archives expand executables (lua54.exe, luac54.exe, ...) into the install
+    -- root next to the DLL. We add aliases (lua.exe, luac.exe, wlua.exe) in the same folder
+    -- so users can invoke them by their canonical names. env_keys.lua already prepends the
+    -- install root to PATH, so a separate bin/ directory isn't needed.
     local lua_exe = path .. "\\" .. pkg_meta.executable_prefix .. ".exe"
     if not file_exists(lua_exe) then
         error("LuaBinaries executable not found at " .. lua_exe)
@@ -66,25 +67,17 @@ local function InstallWindowsLuaBinaries(path, lua_version)
 
     local copies = {
         { src = lua_exe, dst = path .. "\\lua.exe" },
-        { src = lua_exe, dst = bin_dir .. "\\lua.exe" },
     }
 
     local luac_prefix = "luac" .. string.sub(pkg_meta.executable_prefix, 4)
     local luac_exe = path .. "\\" .. luac_prefix .. ".exe"
     if file_exists(luac_exe) then
         table.insert(copies, { src = luac_exe, dst = path .. "\\luac.exe" })
-        table.insert(copies, { src = luac_exe, dst = bin_dir .. "\\luac.exe" })
     end
 
     local wlua_exe = path .. "\\" .. pkg_meta.wlua_prefix .. ".exe"
     if file_exists(wlua_exe) then
         table.insert(copies, { src = wlua_exe, dst = path .. "\\wlua.exe" })
-        table.insert(copies, { src = wlua_exe, dst = bin_dir .. "\\wlua.exe" })
-    end
-
-    local lua_dll = path .. "\\" .. pkg_meta.dll_name
-    if file_exists(lua_dll) then
-        table.insert(copies, { src = lua_dll, dst = bin_dir .. "\\" .. pkg_meta.dll_name })
     end
 
     for _, item in ipairs(copies) do

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -41,9 +41,10 @@ $luacExe = Join-Path $installDir 'luac%s.exe'
 $wluaExe = Join-Path $installDir '%s.exe'
 $luaDll = Join-Path $installDir '%s'
 if (-not (Test-Path $luaExe)) { throw 'LuaBinaries executable package layout is unexpected.' }
+Copy-Item -Path $luaExe -Destination (Join-Path $installDir 'lua.exe') -Force
 Copy-Item -Path $luaExe -Destination (Join-Path $binDir 'lua.exe') -Force
-if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force }
-if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force }
+if (Test-Path $luacExe) { Copy-Item -Path $luacExe -Destination (Join-Path $installDir 'luac.exe') -Force; Copy-Item -Path $luacExe -Destination (Join-Path $binDir 'luac.exe') -Force }
+if (Test-Path $wluaExe) { Copy-Item -Path $wluaExe -Destination (Join-Path $installDir 'wlua.exe') -Force; Copy-Item -Path $wluaExe -Destination (Join-Path $binDir 'wlua.exe') -Force }
 if (Test-Path $luaDll) { Copy-Item -Path $luaDll -Destination (Join-Path $binDir '%s') -Force }
 ]=],
         path,

--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -14,16 +14,18 @@ function PLUGIN:PreInstall(ctx)
     local download_url
 
     if RUNTIME.osType == "windows" and Utils.use_windows_luabinaries() then
-        local package = Utils.get_windows_luabinaries_package(lua_version)
-        if package == nil then
+        local pkg_meta = Utils.get_windows_luabinaries_package(lua_version)
+        if pkg_meta == nil then
             error("LuaBinaries does not provide a Windows binary for version " ..
-                lua_version .. ". Disable VFOX_LUA_WINDOWS_LUABINARIES or choose one of: 5.5.0, 5.4.8, 5.3.6, 5.2.4.")
+                lua_version .. ". Disable VFOX_LUA_WINDOWS_LUABINARIES or choose one of: " ..
+                Utils.get_windows_luabinaries_versions_text() .. ".")
         end
 
-        print("lua download url: " .. package.url)
+        print("lua download url: " .. pkg_meta.url)
         return {
             version = lua_version,
-            url = package.url,
+            url = pkg_meta.url,
+            sha256 = pkg_meta.sha256,
         }
     end
 

--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -22,6 +22,11 @@ function PLUGIN:PreInstall(ctx)
         end
 
         print("lua download url: " .. pkg_meta.url)
+        -- LuaBinaries is distributed via SourceForge's mirror autoselect, which redirects to
+        -- a rotating set of mirrors. vfox computed checksums sometimes hashed the redirect HTML
+        -- instead of the archive bytes, so the integrity check was unreliable. Until upstream
+        -- publishes signed checksums we can pin, the opt-in install relies on HTTPS only —
+        -- documented as a trade-off in the README.
         return {
             version = lua_version,
             url = pkg_meta.url,

--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -25,7 +25,6 @@ function PLUGIN:PreInstall(ctx)
         return {
             version = lua_version,
             url = pkg_meta.url,
-            sha256 = pkg_meta.sha256,
         }
     end
 

--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -13,6 +13,20 @@ function PLUGIN:PreInstall(ctx)
     local lua_version = ctx.version
     local download_url
 
+    if RUNTIME.osType == "windows" and Utils.use_windows_luabinaries() then
+        local package = Utils.get_windows_luabinaries_package(lua_version)
+        if package == nil then
+            error("LuaBinaries does not provide a Windows binary for version " ..
+                lua_version .. ". Disable VFOX_LUA_WINDOWS_LUABINARIES or choose one of: 5.5.0, 5.4.8, 5.3.6, 5.2.4.")
+        end
+
+        print("lua download url: " .. package.url)
+        return {
+            version = lua_version,
+            url = package.url,
+        }
+    end
+
     local v, checksum = Utils.get_version_info(lua_version)
     if not v then
         error("Version " .. lua_version .. " not found in https://www.lua.org/ftp/.")

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -1,6 +1,36 @@
 local http = require("http")
 
 local lua_utils = {}
+local windows_luabinaries_packages = {
+    ["5.5.0"] = {
+        archive_name = "lua-5.5.0_Win64_bin.zip",
+        relative_path = "5.5.0/Tools%20Executables/lua-5.5.0_Win64_bin.zip",
+        executable_prefix = "lua55",
+        wlua_prefix = "wlua55",
+        dll_name = "lua55.dll",
+    },
+    ["5.4.8"] = {
+        archive_name = "lua-5.4.8_Win64_bin.zip",
+        relative_path = "5.4.8/Tools%20Executables/lua-5.4.8_Win64_bin.zip",
+        executable_prefix = "lua54",
+        wlua_prefix = "wlua54",
+        dll_name = "lua54.dll",
+    },
+    ["5.3.6"] = {
+        archive_name = "lua-5.3.6_Win64_bin.zip",
+        relative_path = "5.3.6/Tools%20Executables/lua-5.3.6_Win64_bin.zip",
+        executable_prefix = "lua53",
+        wlua_prefix = "wlua53",
+        dll_name = "lua53.dll",
+    },
+    ["5.2.4"] = {
+        archive_name = "lua-5.2.4_Win64_bin.zip",
+        relative_path = "5.2.4/Tools%20Executables/lua-5.2.4_Win64_bin.zip",
+        executable_prefix = "lua52",
+        wlua_prefix = "wlua52",
+        dll_name = "lua52.dll",
+    },
+}
 
 local function parse_version_line(line)
     return string.match(line, "([^,]+),([^,]+)")
@@ -40,6 +70,31 @@ function lua_utils.get_version_info(lua_version)
     end
 
     return nil, nil
+end
+
+function lua_utils.use_windows_luabinaries()
+    local flag = os.getenv("VFOX_LUA_WINDOWS_LUABINARIES")
+    return flag ~= nil and flag ~= "" and flag ~= "0" and flag ~= "false"
+end
+
+function lua_utils.get_windows_luabinaries_package(lua_version)
+    if RUNTIME.osType ~= "windows" then
+        return nil
+    end
+
+    local package = windows_luabinaries_packages[lua_version]
+    if package == nil then
+        return nil
+    end
+
+    return {
+        archive_name = package.archive_name,
+        executable_prefix = package.executable_prefix,
+        wlua_prefix = package.wlua_prefix,
+        dll_name = package.dll_name,
+        url = "https://sourceforge.net/projects/luabinaries/files/" ..
+            package.relative_path .. "/download?use_mirror=autoselect",
+    }
 end
 
 function lua_utils.is_dir(path)

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -8,6 +8,7 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua55",
         wlua_prefix = "wlua55",
         dll_name = "lua55.dll",
+        sha256 = "7825cb261d0dc61cb0e1511d451ceaf10bf72d2bba1855bfd3350add190e0024",
     },
     ["5.4.8"] = {
         archive_name = "lua-5.4.8_Win64_bin.zip",
@@ -15,6 +16,7 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua54",
         wlua_prefix = "wlua54",
         dll_name = "lua54.dll",
+        sha256 = "9c5d151bfe2b62bd685d88bd1963c17dd5ea2fed37defcda7c02ee6e226bcc39",
     },
     ["5.3.6"] = {
         archive_name = "lua-5.3.6_Win64_bin.zip",
@@ -22,6 +24,7 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua53",
         wlua_prefix = "wlua53",
         dll_name = "lua53.dll",
+        sha256 = "5150a30db5b62956d1bca4c2f3e5d1e08c00e398d8c902f0572b09f014012287",
     },
     ["5.2.4"] = {
         archive_name = "lua-5.2.4_Win64_bin.zip",
@@ -29,6 +32,7 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua52",
         wlua_prefix = "wlua52",
         dll_name = "lua52.dll",
+        sha256 = "6cc8153640b5c1fc4632f18dadaa8696c5b7aef85e885245280d7e31011549d9",
     },
 }
 
@@ -77,24 +81,44 @@ function lua_utils.use_windows_luabinaries()
     return flag ~= nil and flag ~= "" and flag ~= "0" and flag ~= "false"
 end
 
+function lua_utils.get_windows_luabinaries_versions()
+    local versions = {}
+    for version, _ in pairs(windows_luabinaries_packages) do
+        table.insert(versions, version)
+    end
+    table.sort(versions, function(a, b)
+        return a > b
+    end)
+    return versions
+end
+
+function lua_utils.get_windows_luabinaries_versions_text()
+    return table.concat(lua_utils.get_windows_luabinaries_versions(), ", ")
+end
+
 function lua_utils.get_windows_luabinaries_package(lua_version)
     if RUNTIME.osType ~= "windows" then
         return nil
     end
 
-    local package = windows_luabinaries_packages[lua_version]
-    if package == nil then
+    local pkg_meta = windows_luabinaries_packages[lua_version]
+    if pkg_meta == nil then
         return nil
     end
 
     return {
-        archive_name = package.archive_name,
-        executable_prefix = package.executable_prefix,
-        wlua_prefix = package.wlua_prefix,
-        dll_name = package.dll_name,
+        archive_name = pkg_meta.archive_name,
+        executable_prefix = pkg_meta.executable_prefix,
+        wlua_prefix = pkg_meta.wlua_prefix,
+        dll_name = pkg_meta.dll_name,
+        sha256 = pkg_meta.sha256,
         url = "https://sourceforge.net/projects/luabinaries/files/" ..
-            package.relative_path .. "/download?use_mirror=autoselect",
+            pkg_meta.relative_path .. "/download?use_mirror=autoselect",
     }
+end
+
+function lua_utils.is_success_status(status)
+    return status == true or status == 0
 end
 
 function lua_utils.is_dir(path)

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -8,7 +8,6 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua55",
         wlua_prefix = "wlua55",
         dll_name = "lua55.dll",
-        sha256 = "7825cb261d0dc61cb0e1511d451ceaf10bf72d2bba1855bfd3350add190e0024",
     },
     ["5.4.8"] = {
         archive_name = "lua-5.4.8_Win64_bin.zip",
@@ -16,7 +15,6 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua54",
         wlua_prefix = "wlua54",
         dll_name = "lua54.dll",
-        sha256 = "9c5d151bfe2b62bd685d88bd1963c17dd5ea2fed37defcda7c02ee6e226bcc39",
     },
     ["5.3.6"] = {
         archive_name = "lua-5.3.6_Win64_bin.zip",
@@ -24,7 +22,6 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua53",
         wlua_prefix = "wlua53",
         dll_name = "lua53.dll",
-        sha256 = "5150a30db5b62956d1bca4c2f3e5d1e08c00e398d8c902f0572b09f014012287",
     },
     ["5.2.4"] = {
         archive_name = "lua-5.2.4_Win64_bin.zip",
@@ -32,7 +29,6 @@ local windows_luabinaries_packages = {
         executable_prefix = "lua52",
         wlua_prefix = "wlua52",
         dll_name = "lua52.dll",
-        sha256 = "6cc8153640b5c1fc4632f18dadaa8696c5b7aef85e885245280d7e31011549d9",
     },
 }
 
@@ -111,7 +107,6 @@ function lua_utils.get_windows_luabinaries_package(lua_version)
         executable_prefix = pkg_meta.executable_prefix,
         wlua_prefix = pkg_meta.wlua_prefix,
         dll_name = pkg_meta.dll_name,
-        sha256 = pkg_meta.sha256,
         url = "https://sourceforge.net/projects/luabinaries/files/" ..
             pkg_meta.relative_path .. "/download?use_mirror=autoselect",
     }


### PR DESCRIPTION
## Summary
Add an opt-in Windows installation path that downloads prebuilt LuaBinaries packages instead of compiling Lua from source.

## Changes
- add `VFOX_LUA_WINDOWS_LUABINARIES=1` to switch Windows installs from source builds to LuaBinaries packages
- map supported LuaBinaries versions and normalize versioned executables like `lua54.exe` into `lua.exe`/`luac.exe`
- document the Windows opt-in flow in the README
- add a dedicated GitHub Actions job that exercises Windows LuaBinaries installs for `5.5.0`, `5.4.8`, and `5.3.6`

## Testing
- `git diff --check HEAD~3..HEAD`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/e2e_test.yaml')"`
- manual download validation for LuaBinaries `Win64_bin.zip` packages for `5.5.0`, `5.4.8`, `5.3.6`, `5.2.4`

## Notes
- the default Windows install path remains the existing MSYS2 source-build flow
- the LuaBinaries option currently supports the verified versions `5.5.0`, `5.4.8`, `5.3.6`, and `5.2.4`
